### PR TITLE
user-defines note regarding Deviation and OPENTX_SYNC

### DIFF
--- a/docs/software/user-defines.md
+++ b/docs/software/user-defines.md
@@ -96,6 +96,8 @@ These features enable **lower latency** 🏃‍♂️ and **offset** from the Op
 
 Both require [OpenTX `2.3.12`](https://www.open-tx.org/) or above. In order to install it, you will have to use OpenTX companion application. 
 
+Deviation radio users such as those with the T8SGv2/v3 should disable this feature.
+
 You can also use [EdgeTX](https://github.com/EdgeTX/edgetx).
 
 ```


### PR DESCRIPTION
Adding a note to make it easier for DeviationTX users to find out which settings to disable- now they can CTRL+F Deviation and find both of the relevant settings.